### PR TITLE
Textfield consolidate validation

### DIFF
--- a/components/base/editor-element/editor-element.js
+++ b/components/base/editor-element/editor-element.js
@@ -155,6 +155,44 @@ class EditorProxy {
 }
 
 /**
+ * Element validation error class
+ */
+export class ElementValidationError extends Error {
+  constructor(sourceElement, message, code, payload) {
+    super(message);
+    this.code = code || null;
+    this.sourceElement = sourceElement || null;
+    this.payload = payload || {};
+  }
+}
+
+/**
+ * Event type to trigger ck-editor validation event.
+ */
+export class ElementValidationErrorEvent extends CustomEvent {
+  constructor(error) {
+    super(`ck-editor:element-validation-error`, {
+      detail: error,
+      bubbles: true,
+      composed: true
+    });
+  }
+}
+
+/**
+ * Event type to trigger ck-editor validation event.
+ */
+export class ElementValidationErrorResolvedEvent extends CustomEvent {
+  constructor(sourceElement) {
+    super(`ck-editor:element-validation-error-resolved`, {
+      detail: sourceElement,
+      bubbles: true,
+      composed: true
+    });
+  }
+}
+
+/**
  * Event type to communicate with an external user interface.
  */
 class RequestInformationEvent extends CustomEvent {
@@ -228,5 +266,57 @@ export default class EditorElement extends LitElement {
    */
   requestInformation(type, detail, callback) {
     this.dispatchEvent(new RequestInformationEvent(type, detail, callback));
+  }
+
+  /**
+   * Trigger an element validation and emit validation events.
+   *
+   * @todo: provide
+   */
+  validate() {}
+
+  /**
+   * Return true if an element does not validate.
+   *
+   * @returns Boolean
+   */
+  hasError() {}
+
+  /**
+   * Instantiates an ElementValidationError.
+   *
+   * @param message
+   * @param code
+   * @param payload
+   * @returns {ElementValidationError}
+   */
+  createElementValidationError(message, code, payload) {
+    // @todo: make sure that the call stack is better and doesn't end up "here" instead of in the calling location.
+    return new ElementValidationError(this, message, code, payload);
+  }
+
+  /**
+   * Emits an element validation error.
+   *
+   * @param message
+   * @param code
+   * @param payload
+   * @returns {boolean}
+   */
+  emitElementValidationErrorEvent(message, code, payload) {
+    return this.dispatchEvent(
+      new ElementValidationErrorEvent(
+        this.createElementValidationError(message, code, payload)
+      )
+    );
+  }
+
+  /**
+   * Emits an element validation error resolution event.
+   *
+   * @returns {boolean}
+   */
+  emitElementValidationErrorResolvedEvent() {
+    return this.dispatchEvent(new ElementValidationErrorResolvedEvent(this));
   }
 }

--- a/components/base/editor/editor.js
+++ b/components/base/editor/editor.js
@@ -3,6 +3,7 @@ import { LitElement, html } from "lit-element";
 import { eventType } from "./operations";
 
 import text from "!raw-loader!./templates/text.html";
+import textfield from "!raw-loader!./templates/textfield.html";
 import added from "!raw-loader!./templates/added.html";
 import removed from "!raw-loader!./templates/removed.html";
 import gallery from "!raw-loader!./templates/gallery.html";
@@ -140,6 +141,7 @@ Editor.showErrors = story => {
 Editor.dummySetup = story => {
   Editor.templates = {
     text,
+    textfield,
     media,
     image: () =>
       image
@@ -159,6 +161,7 @@ global.addEventListener(
   event => {
     event.respond([
       { id: "text", label: "Text", icon: "text" },
+      { id: "textfield", label: "Textfield", icon: "text" },
       { id: "image", label: "Image", icon: "image" },
       { id: "gallery", label: "Gallery", icon: "carousel" },
       { id: "media", label: "Media", icon: "image" },

--- a/components/base/editor/editor.js
+++ b/components/base/editor/editor.js
@@ -7,6 +7,7 @@ import added from "!raw-loader!./templates/added.html";
 import removed from "!raw-loader!./templates/removed.html";
 import gallery from "!raw-loader!./templates/gallery.html";
 import image from "!raw-loader!./templates/image.html";
+import media from "!raw-loader!./templates/media.html";
 import columns from "!raw-loader!./templates/columns.html";
 
 export default class Editor extends LitElement {
@@ -139,6 +140,7 @@ Editor.showErrors = story => {
 Editor.dummySetup = story => {
   Editor.templates = {
     text,
+    media,
     image: () =>
       image
         .replace("%width", 800)
@@ -159,6 +161,7 @@ global.addEventListener(
       { id: "text", label: "Text", icon: "text" },
       { id: "image", label: "Image", icon: "image" },
       { id: "gallery", label: "Gallery", icon: "carousel" },
+      { id: "media", label: "Media", icon: "image" },
       { id: "columns", label: "Columns", icon: "misc" }
     ]);
   },

--- a/components/base/editor/editor.stories.js
+++ b/components/base/editor/editor.stories.js
@@ -1,5 +1,6 @@
 import { storiesOf } from "@storybook/html";
 import "../../gallery/gallery";
+import "../../media/media";
 import "../placeholder/placeholder";
 import "!style-loader!css-loader!./editor.css";
 import page from "!raw-loader!./templates/page.html";

--- a/components/base/editor/templates/gallery.html
+++ b/components/base/editor/templates/gallery.html
@@ -1,1 +1,1 @@
-<ck-section><ck-gallery ck-min="1" ck-max="3" ck-contains="image">%content</ck-gallery></ck-section>
+<ck-section><ck-gallery ck-min="1" ck-max="3" ck-contains="image media">%content</ck-gallery></ck-section>

--- a/components/base/editor/templates/gallery.html
+++ b/components/base/editor/templates/gallery.html
@@ -1,1 +1,1 @@
-<ck-section><ck-gallery ck-min="1" ck-max="3" ck-contains="image media">%content</ck-gallery></ck-section>
+<ck-section><ck-gallery ck-min="1" ck-max="3" ck-contains="image media textfield">%content</ck-gallery></ck-section>

--- a/components/base/editor/templates/media.html
+++ b/components/base/editor/templates/media.html
@@ -1,0 +1,3 @@
+<ck-section>
+    <ck-media data-media-uuid="" data-media-display=""></ck-media>
+</ck-section>

--- a/components/base/editor/templates/textfield.html
+++ b/components/base/editor/templates/textfield.html
@@ -1,0 +1,3 @@
+<ck-section>
+    <ck-textfield ck-min="3" ck-max="9" ck-message-helper="here to help you"><span contenteditable="true">This is editable</span></ck-textfield>
+</ck-section>

--- a/components/base/placeholder/placeholder.js
+++ b/components/base/placeholder/placeholder.js
@@ -15,6 +15,7 @@ const icons = {
   close: closeIcon,
   formatted_text: formattedTextIcon,
   carousel: carouselIcon,
+  media: imageIcon,
   image: imageIcon,
   misc: miscIcon,
   text: textIcon,

--- a/components/button/button.js
+++ b/components/button/button.js
@@ -15,11 +15,20 @@ export default class Button extends EditorElement {
     };
   }
 
+  hasError() {
+    return this.error;
+  }
+
   validate() {
     const target = this.target && !!this.target.toString().trim();
     const innerText = !!this.innerText.trim().length;
     // @todo: should we validate target to be a valid URL/fragment.
     this.error = !((target && innerText) || (!target && !innerText));
+    if (this.error) {
+      this.emitElementValidationErrorEvent(
+        "You must provide a link target and a link text or leave both empty."
+      );
+    }
   }
 
   setupMutationObserver() {

--- a/components/button/button.js
+++ b/components/button/button.js
@@ -10,18 +10,59 @@ const iconLink = svg`
 export default class Button extends EditorElement {
   static get properties() {
     return {
-      target: { type: String, attribute: "link-target" }
+      target: { type: String, attribute: "link-target" },
+      error: Boolean
     };
   }
 
-  constructor() {
-    super();
-    this.target = null;
+  validate() {
+    const target = this.target && !!this.target.toString().trim();
+    const innerText = !!this.innerText.trim().length;
+    // @todo: should we validate target to be a valid URL/fragment.
+    this.error = !((target && innerText) || (!target && !innerText));
+  }
+
+  setupMutationObserver() {
+    /* global MutationObserver */
+    this.observer = new MutationObserver(this.validate.bind(this));
+    this.observer.observe(this, {
+      childList: true,
+      subtree: true,
+      characterData: true
+    });
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.setupMutationObserver();
+
+    // Textfield errors immediately highlighted
+    this.requestInformation("show-errors", {}, showErrors => {
+      if (showErrors) {
+        this.validate();
+      }
+    });
+  }
+
+  disconnectedCallback() {
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+  }
+
+  updated(properties) {
+    if (properties.has("target")) {
+      this.validate();
+    }
   }
 
   render() {
     return html`
-      <div class="button ${this.target ? "linked" : "not-linked"}">
+      <div
+        class="button ${this.target ? "linked" : "not-linked"} ${this.error
+          ? "error"
+          : ""}"
+      >
         <div class="button__content">
           <slot></slot>
         </div>
@@ -54,6 +95,7 @@ Button.styles = css`
     display: inline-block;
     --icon-size: 2em;
     --icon-color: black;
+    --color-red: #d32323;
     --background-color: #ffbb15;
     background: var(--background-color);
     border-radius: 3em;
@@ -91,5 +133,9 @@ Button.styles = css`
 
   .button.not-linked svg {
     opacity: 0.5;
+  }
+
+  .button.error {
+    outline: 1px solid var(--color-red);
   }
 `;

--- a/components/button/button.js
+++ b/components/button/button.js
@@ -20,14 +20,18 @@ export default class Button extends EditorElement {
   }
 
   validate() {
-    const target = this.target && !!this.target.toString().trim();
+    const hadError = this.error;
+
+    const target = this.target && !!this.target.toString().trim().length;
     const innerText = !!this.innerText.trim().length;
     // @todo: should we validate target to be a valid URL/fragment.
     this.error = !((target && innerText) || (!target && !innerText));
-    if (this.error) {
+    if (!hadError && this.error) {
       this.emitElementValidationErrorEvent(
         "You must provide a link target and a link text or leave both empty."
       );
+    } else if (hadError && !this.error) {
+      this.emitElementValidationErrorResolvedEvent();
     }
   }
 

--- a/components/button/button.md
+++ b/components/button/button.md
@@ -1,3 +1,6 @@
 # Button
 
-A button element that can be used to store a 
+A button element that can be used to store a descriptive text/markup (any kind of HTML) and a link target.
+
+Following validation is applied to the element: either both contained text/markup and link target are empty/null or
+both are filled out.

--- a/components/button/button.stories.js
+++ b/components/button/button.stories.js
@@ -10,7 +10,7 @@ import Editor from "../base/editor/editor";
  *
  * @param document
  */
-function addSelectLinkEventHandler(document) {
+function addEventHandlers(document) {
   document.addEventListener(
     "ck-editor:select-link",
     event => {
@@ -22,6 +22,9 @@ function addSelectLinkEventHandler(document) {
     },
     { capture: true }
   );
+  document.addEventListener("ck-editor:element-validation-error", event => {
+    console.log("ck-editor:element-validation-error", event);
+  });
 }
 
 storiesOf("Button", module)
@@ -38,7 +41,7 @@ storiesOf("Button", module)
       button.style.setProperty("--icon-color", "white");
       button.style.borderRadius = "1.5em";
       button.setAttribute("contenteditable", true);
-      addSelectLinkEventHandler(document);
+      addEventHandlers(document);
       return button;
     },
     {
@@ -52,7 +55,7 @@ storiesOf("Button", module)
   .add(
     "Errors",
     () => {
-      addSelectLinkEventHandler(document);
+      addEventHandlers(document);
       return `<ck-button contenteditable="true"><p>Please enter either A) text and link or B) no text and no link!</p></ck-textfield>`;
     },
     {

--- a/components/button/button.stories.js
+++ b/components/button/button.stories.js
@@ -3,6 +3,27 @@ import buttonNotes from "./button.md";
 import "./index";
 import Editor from "../base/editor/editor";
 
+/**
+ * Helper function to add ck-editor:select-link event handler.
+ *
+ * @todo: consider converting to a decorator.
+ *
+ * @param document
+ */
+function addSelectLinkEventHandler(document) {
+  document.addEventListener(
+    "ck-editor:select-link",
+    event => {
+      if (event.detail.target) {
+        event.respond(null);
+      } else {
+        event.respond("http://drupal.org");
+      }
+    },
+    { capture: true }
+  );
+}
+
 storiesOf("Button", module)
   .addDecorator(Editor.decorator)
   .add(
@@ -17,18 +38,22 @@ storiesOf("Button", module)
       button.style.setProperty("--icon-color", "white");
       button.style.borderRadius = "1.5em";
       button.setAttribute("contenteditable", true);
-      document.addEventListener(
-        "ck-editor:select-link",
-        event => {
-          if (event.detail.target) {
-            event.respond(null);
-          } else {
-            event.respond("http://drupal.org");
-          }
-        },
-        { capture: true }
-      );
+      addSelectLinkEventHandler(document);
       return button;
+    },
+    {
+      notes: { markdown: buttonNotes }
+    }
+  );
+
+storiesOf("Button", module)
+  .addDecorator(Editor.decorator)
+  .addDecorator(Editor.showErrors)
+  .add(
+    "Errors",
+    () => {
+      addSelectLinkEventHandler(document);
+      return `<ck-button contenteditable="true"><p>Please enter either A) text and link or B) no text and no link!</p></ck-textfield>`;
     },
     {
       notes: { markdown: buttonNotes }

--- a/components/gallery/gallery.css
+++ b/components/gallery/gallery.css
@@ -1,6 +1,7 @@
 :host {
   --color-blue: #004adc;
   --color-black: #222330;
+  --color-red: #d32323;
   --color-black-80: rgba(0, 0, 0, 0.8);
   --color-black-60: rgba(0, 0, 0, 0.6);
   --color-black-30: rgba(0, 0, 0, 0.3);
@@ -23,6 +24,10 @@
   display: inline-block;
   margin: auto;
   overflow: hidden;
+}
+
+.ck-gallery.error .ck-gallery__controls {
+  border: 1px solid var(--color-red);
 }
 
 .disabled {
@@ -92,6 +97,9 @@
   cursor: pointer;
   font-size: 12px;
   transition: background-color 0.35s ease;
+}
+.ck-gallery__dot-item.error {
+  background-color: var(--color-red) !important;
 }
 
 .ck-gallery__add {

--- a/components/gallery/gallery.stories.js
+++ b/components/gallery/gallery.stories.js
@@ -3,6 +3,40 @@ import "./index";
 
 import Editor from "../base/editor/editor";
 
+function randomUuid() {
+  return `${200 + Math.ceil(Math.random() * 200)}`;
+}
+
+function addMediaHandlers(document) {
+  document.addEventListener(
+    "ck-editor:media-select",
+    event => {
+      console.log("HHHLHLHLH");
+      event.respond(randomUuid());
+    },
+    { capture: true }
+  );
+  document.addEventListener(
+    "ck-editor:media-preview",
+    event => {
+      window.setTimeout(() => {
+        event.respond(
+          `<img width="100%" src="https://placekitten.com/500/${
+            event.detail.uuid
+          }" />`
+        );
+      }, 200);
+    },
+    { capture: true }
+  );
+}
+
+function addValidationHandler(document) {
+  document.addEventListener("ck-editor:element-validation-error", event => {
+    console.log("ck-editor:element-validation-error", event);
+  });
+}
+
 storiesOf("Gallery", module)
   .addDecorator(Editor.dummySetup)
   .addDecorator(Editor.decorator)
@@ -16,3 +50,13 @@ storiesOf("Gallery", module)
     () =>
       `<ck-gallery ck-contains="image text" ck-max="3" style="width: 500px">${Editor.templates.image()}</ck-gallery>`
   );
+
+storiesOf("Gallery", module)
+  .addDecorator(Editor.dummySetup)
+  .addDecorator(Editor.decorator)
+  .addDecorator(Editor.showErrors)
+  .add("Errors", () => {
+    addMediaHandlers(document);
+    addValidationHandler(document);
+    return `<ck-gallery ck-contains="image text media" style="width: 500px">${Editor.templates.image()}</ck-gallery>`;
+  });

--- a/components/media/media.js
+++ b/components/media/media.js
@@ -39,13 +39,27 @@ export default class Media extends EditorElement {
     };
   }
 
+  validate() {
+    const hadError = this.error;
+
+    this.error = !this.mediaUuid;
+    if (!hadError && this.error) {
+      this.emitElementValidationErrorEvent(
+        "Media is required",
+        "media_required"
+      );
+    } else if (hadError && !this.error) {
+      this.emitElementValidationErrorResolvedEvent();
+    }
+  }
+
   connectedCallback() {
     super.connectedCallback();
 
     // Textfield errors immediately highlighted
     this.requestInformation("show-errors", {}, showErrors => {
       if (showErrors) {
-        this.error = !this.mediaUuid;
+        this.validate();
       }
     });
   }
@@ -69,7 +83,7 @@ export default class Media extends EditorElement {
   updated(properties) {
     this.previewPane = this.shadowRoot.querySelector(".ck-media__preview");
     if (properties.has("mediaUuid") && this.mediaUuid) {
-      this.error = !this.mediaUuid;
+      this.validate();
       this.renderPreview();
     }
 

--- a/components/section/section.js
+++ b/components/section/section.js
@@ -49,7 +49,8 @@ export default class Section extends EditorElement {
       containerMax: { type: Number },
       containerItems: { type: Number },
       containerSections: { type: String },
-      isHovered: { type: Boolean }
+      isHovered: { type: Boolean },
+      error: { type: Boolean }
     };
   }
 
@@ -81,6 +82,21 @@ export default class Section extends EditorElement {
     // this.addEventListener("mouseout", event => {
     //   this.isHovered = false;
     // });
+
+    this.addEventListener("ck-editor:element-validation-error", event => {
+      this.error = true;
+    });
+
+    this.addEventListener(
+      "ck-editor:element-validation-error-resolved",
+      event => {
+        this.error = false;
+      }
+    );
+  }
+
+  hasError() {
+    return this.error;
   }
 
   connectedCallback() {

--- a/components/textfield/textfield.js
+++ b/components/textfield/textfield.js
@@ -20,6 +20,7 @@ export default class TextField extends EditorElement {
     super.connectedCallback();
 
     this.querySelectorAll(["[contenteditable]"]).forEach(el => {
+      /* global MutationObserver */
       const observer = new MutationObserver(this.validate);
       observer.observe(el, {
         childList: true,
@@ -57,6 +58,9 @@ export default class TextField extends EditorElement {
   }
 
   validate() {
+    const hadPatternError = this.hasPatternError;
+    const hadLengthError = this.hasLengthError;
+
     // MAX
     if (this.hasAttribute("ck-max")) this.maxValidation();
     // MIN
@@ -67,11 +71,16 @@ export default class TextField extends EditorElement {
     // Pattern
     if (this.hasAttribute("ck-pattern")) this.patternValidation();
 
-    if (this.hasPatternError) {
+    if (!hadPatternError && this.hasPatternError) {
       this.emitElementValidationErrorEvent(this.errorMessage, "pattern_error");
+    } else if (hadPatternError && !this.hasPatternError) {
+      this.emitElementValidationErrorResolvedEvent();
     }
-    if (this.hasLengthError) {
+
+    if (!hadLengthError && this.hasLengthError) {
       this.emitElementValidationErrorEvent(this.errorMessage, "length_error");
+    } else if (hadLengthError && !this.hasLengthError) {
+      this.emitElementValidationErrorResolvedEvent();
     }
   }
 

--- a/components/textfield/textfield.js
+++ b/components/textfield/textfield.js
@@ -66,6 +66,13 @@ export default class TextField extends EditorElement {
       this.rangeValidation();
     // Pattern
     if (this.hasAttribute("ck-pattern")) this.patternValidation();
+
+    if (this.hasPatternError) {
+      this.emitElementValidationErrorEvent(this.errorMessage, "pattern_error");
+    }
+    if (this.hasLengthError) {
+      this.emitElementValidationErrorEvent(this.errorMessage, "length_error");
+    }
   }
 
   /**

--- a/components/textfield/textfield.js
+++ b/components/textfield/textfield.js
@@ -21,7 +21,7 @@ export default class TextField extends EditorElement {
 
     this.querySelectorAll(["[contenteditable]"]).forEach(el => {
       /* global MutationObserver */
-      const observer = new MutationObserver(this.validate);
+      const observer = new MutationObserver(this.validate.bind(this));
       observer.observe(el, {
         childList: true,
         subtree: true,

--- a/components/textfield/textfield.js
+++ b/components/textfield/textfield.js
@@ -16,6 +16,10 @@ export default class TextField extends EditorElement {
     };
   }
 
+  hasError() {
+    return this.hasLengthError || this.hasPatternError;
+  }
+
   connectedCallback() {
     super.connectedCallback();
 
@@ -34,12 +38,7 @@ export default class TextField extends EditorElement {
         this.hasHelper = false;
       });
 
-      if (this.maxLength && !this.minLength) {
-        el.addEventListener("input", this.handleMax.bind(this));
-      }
-      if (this.maxLength && this.minLength) {
-        el.addEventListener("input", this.rangeValidation.bind(this));
-      }
+      el.addEventListener("input", this.validate.bind(this));
     });
 
     // Textfield errors immediately highlighted
@@ -50,26 +49,33 @@ export default class TextField extends EditorElement {
     });
   }
 
-  handleMax() {
-    this.helper = `${this.maxLength -
-      this.innerText.length} letters remaining.`;
-    this.setHelper();
-    this.maxValidation();
-  }
-
   validate() {
     const hadPatternError = this.hasPatternError;
     const hadLengthError = this.hasLengthError;
 
     // MAX
-    if (this.hasAttribute("ck-max")) this.maxValidation();
+    if (this.maxLength) {
+      this.maxValidation();
+    }
     // MIN
-    if (this.hasAttribute("ck-min")) this.minValidation();
+    if (this.minLength) {
+      this.minValidation();
+    }
     // Range
-    if (this.hasAttribute("ck-max") && this.hasAttribute("ck-min"))
+    if (this.maxLength && this.minLength) {
       this.rangeValidation();
+    }
     // Pattern
-    if (this.hasAttribute("ck-pattern")) this.patternValidation();
+    if (this.pattern) {
+      this.patternValidation();
+    }
+
+    // Adjust message of the helper.
+    if (this.maxLength && !this.minLength) {
+      this.helper = `${this.maxLength -
+        this.innerText.length} letters remaining.`;
+      this.setHelper();
+    }
 
     if (!hadPatternError && this.hasPatternError) {
       this.emitElementValidationErrorEvent(this.errorMessage, "pattern_error");


### PR DESCRIPTION
Building on top of the PR #19 this incrementally refactors bits of the textfield validation to ensure validation events being properly emitted.

To test:

1.  `yarn run storybook`
2. Go to http://localhost:9001/?path=/story/base-editor--default and add a Gallery. Galleries now can also contain a `textfield`. Validation errors and error resolutions should now be reflected in the "Gallery"-error state.
 
